### PR TITLE
Fix syntax error

### DIFF
--- a/scripts/test.ply
+++ b/scripts/test.ply
@@ -11,7 +11,7 @@ kprobe:SyS_*
 	/* printf("flags:%x\n", arg(1)); */
 	/* printf("comm:%s\n", comm()); */
 
-	syscalls[func()].count();
+	$syscalls[func()].count();
 }
 
 /* kprobe:SyS_read */


### PR DESCRIPTION
Hi sir,

I'd like to send a patch which fix the following syntax error in the example script.
error(14): syntax error, unexpected '[', expecting ';' or '}'

Please help to review it. Thanks.

Viller
