### PR TITLE
Correctly undefine used macro

### DIFF
--- a/src/lang/ast.c
+++ b/src/lang/ast.c
@@ -36,7 +36,7 @@ const char *op_str(op_t op)
 	static const char *strs[] = {
 		OP_TABLE
 	};
-#undef TYPE
+#undef OP
 
 	return strs[op];
 }


### PR DESCRIPTION
First thanks for this project! I had some trouble setting it up due to my broken linux headers, but in the end I got it working.

I found this very minor thing in the code. You probably wanted to undefine the previously defined `OP`