### PR TITLE
add initial opensnoop

### DIFF
--- a/scripts/opensnoop.ply
+++ b/scripts/opensnoop.ply
@@ -1,0 +1,26 @@
+#!/usr/bin/env ply
+/*
+ * opensnoop	trace file opens.
+ */
+
+# should have a BEGIN for column headings, pending issue #14
+
+kprobe:do_sys_open
+{
+	# should just save ptr, pending issue #13
+	@path[pid()] = mem(arg(1), "128s");
+}
+
+kretprobe:do_sys_open # should use / @path[pid()] /, pending issue #17 or #13
+{
+	if (retval() > 0) {
+		fd = retval();
+		errno = 0;
+	} else {
+		fd = -1;
+		errno = -1 * retval();
+	}
+
+	printf("%-6d %-16s %4d %3d %s\n", pid(), comm(), fd, errno, @path[pid()]);
+	@path[pid()] = nil;
+}


### PR DESCRIPTION
I think /scripts is a nice example directory of short examples like this, but with a few more features we might want a /tools directory as well that has documented (man page & examples file) tools with arguments. Such tools are going to get verbose fast, once they have command line options (which might mean wrapping in shell).

This particular example documents the missing features with the issue numbers, which I think helps newcomers learn why something is the way it is (because it's pending a fix).