### PR TITLE
profile provider support

### DIFF
--- a/man/ply.1.ronn
+++ b/man/ply.1.ronn
@@ -339,6 +339,15 @@ The probe may then call the following functions:
   `next_prio()` => number <br>
 
 
+### profile
+
+The profile provider supports profiling by allowing the user to specify
+how many times it will fire per-second.  Values of 1-1000 are supported,
+and the profile provider supports two probe formats:
+
+  `profile:[n]hz` => profile on all CPUs N times per second <br>
+  `profile:[c]:[n]hz` => profile on CPU c N times per second <br>
+
 ## EXAMPLE
 
 ### Extracting data

--- a/oneliners.md
+++ b/oneliners.md
@@ -35,3 +35,11 @@ ply -c 'kprobe:SyS_* { @[comm(), pid()].count() }'
 ```
 ply -c 'kprobe:schedule { @[stack()].count() }'
 ```
+
+### Profile
+
+**Sample process names on-cpu 1000 times per second:**
+```
+ply -c 'profile:1000 { @c[comm()].count();}'
+```
+


### PR DESCRIPTION
profile events are enabled via PERF_TYPE_SOFTWARE/PERF_COUNT_SW_CPU_CLOCK
perf event and we use a kprobe firing - perf_swevent_hrtimer() - to catch
the profile events in kernel context.  Profiling on all CPUs and per-CPU
profiling are both supported; see the manual page for details on the
syntax. Admittedly a bit of a hack but thought I'd point at it just in case it's useful.
Thanks!

Signed-off-by: Alan Maguire <alan.maguire@oracle.com>