### PR TITLE
scripts: syscall-fail.ply: fix syntax error

### DIFF
--- a/scripts/syscall-fail.ply
+++ b/scripts/syscall-fail.ply
@@ -2,7 +2,7 @@
 #
 # Attach return-probes
 
-trace:raw_syscalls/sys_exit / ret() < 0 /
+trace:raw_syscalls/sys_exit / (ret() < 0) /
 {
 	@[comm()].count()
 }


### PR DESCRIPTION
When execute the script, the ply parser reports error as below:
  error(6): syntax error, unexpected '{'

This commit is to add bracket for predicate so can dismiss syntax
error.

Signed-off-by: Leo Yan <leo.yan@linaro.org>