### PR TITLE
some kernel function symbols not being resolved when printing stacks

### DIFF
--- a/src/kallsyms.c
+++ b/src/kallsyms.c
@@ -45,6 +45,20 @@ static int ksym_cmp(const void *_key, const void *_member)
 	return 0;
 }
 
+/* Compare two members: for this qsort operation it is sufficient to compare
+ * start addresses.
+ */
+static int ksym_membercmp(const void *_m1, const void *_m2)
+{
+	const ksym_t *m1 = _m1, *m2 = _m2;
+
+	if (m1->start < m2->start)
+		return -1;
+	if (m1->start > m2->start)
+		return 1;
+	return 0;
+}
+
 const ksym_t *ksym_get(ksyms_t *ks, uintptr_t addr)
 {
 	ksym_t key = { .start = addr, .end = addr };
@@ -115,7 +129,6 @@ static int ksyms_cache_build(const char *in, const char *out)
 		} else if (err)
 			goto close_cfp;
 
-		ksym[!i].end = ksym[i].start - 1;
 		if (!fwrite(&ksym[!i], sizeof(ksym[!i]), 1, cfp)) {
 			err = -EIO;
 			goto close_cfp;
@@ -124,8 +137,6 @@ static int ksyms_cache_build(const char *in, const char *out)
 		hdr.n_syms++;
 	}
 
-	/* assume no function larger than 4k */
-	ksym[i].end = ksym[i].start + 0x1000;
 	if (!fwrite(&ksym[i], sizeof(ksym[i]), 1, cfp)) {
 		err = -EIO;
 		goto close_cfp;
@@ -150,7 +161,7 @@ out:
 static int ksyms_cache_open(ksyms_t *ks)
 {
 	struct stat st;
-	int err;
+	int err, i;
 
 	if (stat(KSYMS_CACHE, &st)) {
 		err = ksyms_cache_build("/proc/kallsyms", KSYMS_CACHE);
@@ -165,8 +176,26 @@ static int ksyms_cache_open(ksyms_t *ks)
 	if (ks->cache_fd < 0)
 		return -errno;
 
-	ks->cache = mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE,
+	ks->cache = mmap(NULL, st.st_size, PROT_READ | PROT_WRITE, MAP_PRIVATE,
 			 ks->cache_fd, 0);
+
+	/* For bsearch() to work properly, our cache must be sorted by
+	 * start address.  kallsyms is not guaranteed to be in order from
+	 * low address to high; modules seem to be particularly problematic.
+	 */
+	if (ks->cache) {
+		ksym_t *ksyms = ks->cache->sym;
+		int i;
+
+		qsort(ksyms, ks->cache->hdr.n_syms, sizeof(ksym_t),
+		      ksym_membercmp);
+		/* Now we have sorted we can fill in end values. */
+		for (i = 0; i < ks->cache->hdr.n_syms - 1; i++)
+			ksyms[i].end = ksyms[i+1].start -1;
+		/* assume no function larger than 4k */
+		ksyms[i].end = ksyms[i].start + 0x1000;
+	}
+
 	return ks->cache ? 0 : -ENOENT;
 }
 


### PR DESCRIPTION
    As far as I can tell there is an implicit assumption in the code that
    /proc/kallsyms information is sorted from low address to high already.
    I don't see that on my system (OEL7.4 plus 4.14.7 kernel). For example:
    
    ./ply -c 'kprobe:ip_local_deliver {@c[stack()].count(); }'
    1 probe active
    ^Cde-activating probes
    
    @c:
    
    ip_local_deliver+0x1
    ip_rcv+0x2ea
    __netif_receive_skb_core+0x3dc
    __netif_receive_skb+0x18
    netif_receive_skb_internal+0x45
    napi_gro_receive+0xd5
    <ffffffffa0b5e5e4>
    <ffffffffa0b60a14>
    <ffffffffa0b62df6>
    <ffffffffa0b63ac3>
    <ffffffffa0a17ec8>
    <ffffffffa0a11c0a>
    strp_mod_exit+0x1e7099cd
    strp_mod_exit+0x1e70b25a
    irq_thread_fn+0x1e
    irq_thread+0x13c           6
    
    We see that a number of addresses were not resolved. The reason
    appears to lie in the implicit assumption of sorting; bsearch cannot
    find these symbols since the ksym array is not ordered. We can
    fix this by qsort()ing the mmap()ed representation, and only filling
    in ksym[i].end = ksym[i+1].start -1 once the list is sorted.  With this
    change we see:
    
    ./ply -c 'kprobe:ip_local_deliver {@c[stack()].count(); }'
    1 probe active
    ^Cde-activating probes
    
    @c:
    
        ip_local_deliver+0x1
        ip_rcv+0x2ea
        __netif_receive_skb_core+0x3dc
        __netif_receive_skb+0x18
        netif_receive_skb_internal+0x45
        napi_gro_receive+0xd5
        ieee80211_deliver_skb+0xe4
        __dta_ieee80211_rx_handlers_673+0xd34
        ieee80211_prepare_and_rx_handle+0x936
        ieee80211_rx_napi+0x433
        iwl_mvm_rx_rx_mpdu+0x468
        iwl_mvm_rx+0x5a
        __dta_iwl_pcie_rx_handle_416+0x3ab
        iwl_pcie_irq_handler+0x4b8
        irq_thread_fn+0x1e
        irq_thread+0x13c              12
