### PR TITLE
fix issue #16: don't enable all tracepoints

### DIFF
--- a/src/include/ply/ply.h
+++ b/src/include/ply/ply.h
@@ -53,6 +53,7 @@ struct globals {
 	int debug:1;
 	int dump:1;
 	int timeout;
+	pid_t self;
 
 	size_t map_nelem;
 


### PR DESCRIPTION
these changes use a more targeted approach in enabling/disabling probes.
When enabling k[ret]probes we use the current pid to make the probe unique
system-wide; this allows multiple instances of ply to run.  Also remove
global enable/disable of kprobes/tracepoints as it is not needed.

Signed-off-by: Alan Maguire <alan.maguire@oracle.com>