### PR TITLE
parens should not be required for probe predicates

### DIFF
--- a/oneliners.md
+++ b/oneliners.md
@@ -11,7 +11,7 @@ ply -c 'kretprobe:SyS_read { @.quantize(retval()) }'
 
 **`read()` request size, as a power-of-2 histogram, for reads > 1 kB, grouped by pid:**
 ```
-ply -c 'kprobe:SyS_read / (arg(2) > 1024) / { @[pid()].quantize(arg(2)); }'
+ply -c 'kprobe:SyS_read / arg(2) > 1024 / { @[pid()].quantize(arg(2)); }'
 ```
 
 **`open()` Print process name, pid and the file that was opened:**

--- a/scripts/syscall-fail.ply
+++ b/scripts/syscall-fail.ply
@@ -2,7 +2,7 @@
 #
 # Attach return-probes
 
-trace:raw_syscalls/sys_exit / (ret() < 0) /
+trace:raw_syscalls/sys_exit / ret() < 0 /
 {
 	@[comm()].count()
 }

--- a/src/lang/lex.l
+++ b/src/lang/lex.l
@@ -64,6 +64,15 @@ pspec		{ident}:[*?+@!:_.,/a-zA-Z0-9]*
 "continue"		{ return CONTINUE; }
 "return"		{ return RETURN; }
 
+"/"[ \t\n]*/"{"	{
+			/*
+			 * division in an expr and closing of probe predicate use
+			 * the same '/' symbol; need to resolve the shift-reduce
+			 * conflict.  If next non-whitespace char is '{' we know
+			 * it is a closing predicate.
+			 */
+			return CLOSEPRED;
+		}
 {pspec}			{ yylval->string = strdup(yytext); return PSPEC; }
 {ident}			{ yylval->string = strdup(yytext); return IDENT; }
 {map}			{ yylval->string = strdup(yytext); return MAP;   }
@@ -74,8 +83,9 @@ pspec		{ident}:[*?+@!:_.,/a-zA-Z0-9]*
 ">=" { return GE; }
 "==" { return EQ; }
 "!=" { return NE; }
+"/"  { return DIV; }
 
-[=$.,;+\-*/%<>&\^|!()\[\]{}]	{ return *yytext; }
+[=$.,;+\-*%<>&\^|!()\[\]{}]	{ return *yytext; }
 \"(\\.|[^\\"])*\"	{ yylval->string = strndup(&yytext[1], strlen(yytext) - 2); return STRING; }
 [0-9]+			{ yylval->integer = strtoul(yytext, NULL, 0); return INT; }
 0[xX][0-9a-fA-F]+	{ yylval->integer = strtoul(yytext, NULL, 0); return INT; }

--- a/src/lang/parse.y
+++ b/src/lang/parse.y
@@ -58,9 +58,9 @@ typedef struct node node_t;
 %parse-param { node_t **script }
 %parse-param { yyscan_t scanner }
 
-%token EQ NE LE GE LSH RSH
+%token EQ NE LE GE LSH RSH DIV
 %token NIL IF ELSE UNROLL BREAK CONTINUE RETURN
-%token <string> PSPEC IDENT MAP STRING
+%token <string> PSPEC CLOSEPRED IDENT MAP STRING
 %token <integer> INT
 
 %type <node> script probes probe oblock block stmts stmt assign
@@ -75,7 +75,7 @@ typedef struct node node_t;
 %left '<' LE GE '>'
 %left LSH RSH
 %left '+' '-'
-%left '*' '/' '%'
+%left '*' DIV '%'
 
 /* C if-else associativity */
 %right ')' ELSE
@@ -96,7 +96,7 @@ probes: probe
 ;
 
 probe: PSPEC oblock              { $$ = node_probe_new($1, NULL, $2); }
-     | PSPEC '/' expr '/' oblock { $$ = node_probe_new($1,   $3, $5); }
+     | PSPEC DIV expr CLOSEPRED oblock { $$ = node_probe_new($1,   $3, $5); }
 ;
 
 oblock: %empty { $$ = NULL; }
@@ -174,7 +174,7 @@ binop: expr '|' expr { $$ = node_binop_new($1, OP_OR,  $3); }
      | expr '+' expr { $$ = node_binop_new($1, OP_ADD, $3); }
      | expr '-' expr { $$ = node_binop_new($1, OP_SUB, $3); }
      | expr '*' expr { $$ = node_binop_new($1, OP_MUL, $3); }
-     | expr '/' expr { $$ = node_binop_new($1, OP_DIV, $3); }
+     | expr DIV expr { $$ = node_binop_new($1, OP_DIV, $3); }
      | expr '%' expr { $$ = node_binop_new($1, OP_MOD, $3); }
 ;
 


### PR DESCRIPTION
a probe predicate is defined as an expr in parse.y; however
exprs can contain '/' division symbols, which are also used
to bracket a predicate.  This causes a shift-reduce conflict
for flex, but we can resolve it by having a '/' followed by
a '{' resolve to a CLOSEPRED token while other instances of '/'
resolve to a DIV token.  This change allows us to define probe
predicates without having to use parentheses, e.g. in
syscall-fail.ply.

Signed-off-by: Alan Maguire <alan.maguire@oracle.com>