### PR TITLE
Removed duplicate KPROBE_MAXLEN definition

### DIFF
--- a/src/pvdr/kprobe.c
+++ b/src/pvdr/kprobe.c
@@ -63,8 +63,6 @@ typedef struct profile {
 	kprobe_t *kp;
 } profile_t;
 
-#define	KPROBE_MAXLEN	0x100
-
 static int probe_event_id(kprobe_t *kp, const char *path)
 {
 	FILE *fp;


### PR DESCRIPTION
"#define KPROBE_MAXLEN   0x100" is defined twice within pvdr/kprobe.c, once on line 42 and again on line 66.  Removed the duplicate entry on line 66.