### PR TITLE
build: Fix kernel header installation on ARM64

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,7 +34,11 @@ if KERNEL_DIR
 BUILT_SOURCES += .kernel/include/linux/version.h
 ply_CFLAGS    += -I .kernel/include
 
+if ARCH_AARCH64
+kernelenv := ARCH=arm64
+else
 kernelenv := ARCH=@host_cpu@
+endif
 kernelenv += INSTALL_HDR_PATH=$(shell pwd)/.kernel
 
 .kernel/include/linux/version.h:


### PR DESCRIPTION
When build ply on ARM64, the variable 'host_cpu' is aarch64 and the
makefile uses it so set kernel build environment variable
'ARCH=aarch64', this results in the kernel header installation reports
failure due it cannot find path '$kernel/arch/aarch64'.

The reason for this failure is kernel places ARM64 architecture code in
'$kernel/arch/arm64' but not '$kernel/arch/aarch64'.  This commit fixes
this issue by setting 'ARCH=arm64' for aarch64 building.

Signed-off-by: Leo Yan <leo.yan@linaro.org>