### PR TITLE
man: remove '-A' option

### DIFF
--- a/man/ply.1.ronn
+++ b/man/ply.1.ronn
@@ -15,9 +15,6 @@ using kprobes and tracepoints.
 
 ## OPTIONS
 
-  * `-A`, `--ascii`:
-    Restrict output to ASCII, no Unicode runes.
-
   * `-c` <command>, `--command`=<command>:
     When all probes are running, run <command>. When the command
     exits, stop all probes and exit. The command is run as if invoked


### PR DESCRIPTION
'-A' option is obsolete now.  Remove the description from the man page.

Signed-off-by: SeongJae Park <sj38.park@gmail.com>