### PR TITLE
Fix static link failure

### DIFF
--- a/include/ply/func.h
+++ b/include/ply/func.h
@@ -7,6 +7,8 @@
 #ifndef _FUNC_H
 #define _FUNC_H
 
+#include <sys/queue.h>
+
 struct node;
 struct ply_probe;
 struct type;
@@ -16,6 +18,8 @@ struct func {
 	struct type *type;
 
 	int static_ret:1; 	/* return type is statically known */
+
+	SLIST_ENTRY(func) entry;
 
 	int (*static_validate)(const struct func *, struct node *);
 	int (*type_infer)     (const struct func *, struct node *);

--- a/include/ply/internal.h
+++ b/include/ply/internal.h
@@ -23,4 +23,6 @@
 #include "syscall.h"
 #include "utils.h"
 
+void built_in_init(void);
+
 #endif	/* _PLY_INTERNAL_H */

--- a/include/ply/ply.h
+++ b/include/ply/ply.h
@@ -97,4 +97,6 @@ int  ply_parsef(struct ply *ply, const char *fmt, ...);
 void ply_free  (struct ply *ply);
 int  ply_alloc (struct ply **plyp);
 
+void ply_init(void);
+
 #endif	/* _PLY_H */

--- a/include/ply/provider.h
+++ b/include/ply/provider.h
@@ -9,6 +9,8 @@
 
 #include <linux/bpf.h>
 
+#include <sys/queue.h>
+
 struct ply;
 struct ply_probe;
 struct node;
@@ -16,6 +18,8 @@ struct node;
 struct provider {
 	const char *name;
 	enum bpf_prog_type prog_type;
+
+	SLIST_ENTRY(provider) entry;
 
 	int (*probe)    (struct ply_probe *);
 	int (*sym_alloc)(struct ply_probe *, struct node *);
@@ -26,13 +30,6 @@ struct provider {
 };
 
 struct provider *provider_get(const char *name);
-
-#define __ply_provider __attribute__((		\
-     section("providers"),			\
-     aligned(__alignof__(struct provider))	\
-))
-
-extern struct provider __start_providers;
-extern struct provider __stop_providers;
+void provider_init(void);
 
 #endif	/* _PROVIDER_H */

--- a/src/libply/built-in/aggregation.c
+++ b/src/libply/built-in/aggregation.c
@@ -31,7 +31,7 @@ struct type t_count_func = {
 	.func = { .type = &t_ulong },
 };
 
-__ply_built_in const struct func count_func = {
+static struct func count_func = {
 	.name = "count",
 	.type = &t_count_func,
 	.static_ret = 1,
@@ -296,10 +296,16 @@ static int quantize_type_infer(const struct func *func, struct node *n)
 	return 0;
 }
 
-__ply_built_in const struct func quantize_func = {
+static struct func quantize_func = {
 	.name = "quantize",
 	.type = &t_unary_func,
 	.type_infer = quantize_type_infer,
 
 	.ir_post = quantize_ir_post,
 };
+
+void aggregation_init(void)
+{
+	built_in_register(&count_func);
+	built_in_register(&quantize_func);
+}

--- a/src/libply/built-in/buffer.c
+++ b/src/libply/built-in/buffer.c
@@ -249,7 +249,7 @@ static int stdbuf_static_validate(const struct func *func, struct node *n)
 	return 0;
 }
 
-__ply_built_in const struct func stdbuf_func = {
+static struct func stdbuf_func = {
 	.name = "stdbuf",
 	.type = &t_buffer,
 	.static_ret = 1,
@@ -282,10 +282,16 @@ struct type t_bwrite = {
 	.func = { .type = &t_void, .args = f_bwrite },
 };
 
-__ply_built_in const struct func bwrite_func = {
+static struct func bwrite_func = {
 	.name = "bwrite",
 	.type = &t_bwrite,
 	.static_ret = 1,
 
 	.ir_post = bwrite_ir_post,
 };
+
+void buffer_init(void)
+{
+	built_in_register(&stdbuf_func);
+	built_in_register(&bwrite_func);
+}

--- a/src/libply/built-in/built-in.c
+++ b/src/libply/built-in/built-in.c
@@ -275,7 +275,7 @@ int built_in_ir_pre(struct ply_probe *pb)
 	return 0;
 }
 
-__ply_provider struct provider built_in = {
+struct provider built_in = {
 	.name = "!built-in",
 
 	.sym_alloc = built_in_sym_alloc,

--- a/src/libply/built-in/built-in.c
+++ b/src/libply/built-in/built-in.c
@@ -10,11 +10,15 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/queue.h>
 
 #include <ply/ply.h>
 #include <ply/internal.h>
 
 #include "built-in.h"
+
+SLIST_HEAD(built_in_list, func);
+static struct built_in_list heads = SLIST_HEAD_INITIALIZER(heads);
 
 static struct type t_ctx = {
 	.ttype = T_POINTER,
@@ -29,7 +33,7 @@ static struct type t_ctx = {
 	},
 };
 
-__ply_built_in const struct func ctx_func = {
+static struct func ctx_func = {
 	.name = "ctx",
 	.type = &t_ctx,
 	.static_ret = 1,
@@ -176,7 +180,7 @@ static const struct func ident_func = {
 };
 
 
-__ply_built_in const struct func block_func = {
+static struct func block_func = {
 	.name = "{}",
 	.type = &t_vargs_func,
 	.static_ret = 1,
@@ -188,7 +192,7 @@ static const struct func *built_in_func_get(struct node *n)
 	const struct func *func;
 	int err;
 
-	for (func = &__start_built_ins; func < &__stop_built_ins; func++) {
+	SLIST_FOREACH(func, &heads, entry) {
 		if (!strcmp(func->name, n->expr.func))
 			return func;
 	}
@@ -284,3 +288,22 @@ struct provider built_in = {
 	.ir_pre = built_in_ir_pre,
 
 };
+
+void built_in_register(struct func *func)
+{
+	SLIST_INSERT_HEAD(&heads, func, entry);
+}
+
+void built_in_init(void)
+{
+	built_in_register(&ctx_func);
+	built_in_register(&block_func);
+
+	aggregation_init();
+	buffer_init();
+	flow_init();
+	math_init();
+	memory_init();
+	print_init();
+	proc_init();
+}

--- a/src/libply/built-in/built-in.h
+++ b/src/libply/built-in/built-in.h
@@ -15,4 +15,14 @@
 extern const struct func __start_built_ins;
 extern const struct func __stop_built_ins;
 
+void built_in_register(struct func *func);
+
+void aggregation_init(void);
+void buffer_init(void);
+void flow_init(void);
+void math_init(void);
+void memory_init(void);
+void print_init(void);
+void proc_init(void);
+
 #endif	/* _PLY_BUILT_IN_H */

--- a/src/libply/built-in/flow.c
+++ b/src/libply/built-in/flow.c
@@ -46,7 +46,7 @@ static int iftest_ir_post(const struct func *func, struct node *n,
 	return 0;
 }
 
-__ply_built_in const struct func iftest_func = {
+static struct func iftest_func = {
 	.name = ":iftest",
 	.type = &t_void,
 	.static_ret = 1,
@@ -68,7 +68,7 @@ static int ifjump_ir_post(const struct func *func, struct node *n,
 	return 0;
 }
 
-__ply_built_in const struct func ifjump_func = {
+static struct func ifjump_func = {
 	.name = ":ifjump",
 	.type = &t_void,
 	.static_ret = 1,
@@ -126,7 +126,7 @@ static int if_type_infer(const struct func *func, struct node *n)
 	return 0;
 }
 
-__ply_built_in const struct func if_func = {
+static struct func if_func = {
 	.name = "if",
 	.type = &t_vargs_func,
 	.static_ret = 1,
@@ -201,10 +201,18 @@ static int exit_type_infer(const struct func *func, struct node *n)
 	return 0;
 }
 
-__ply_built_in const struct func exit_func = {
+static struct func exit_func = {
 	.name = "exit",
 	.type = &t_unary_func,
 	.type_infer = exit_type_infer,
 
 	.rewrite = exit_rewrite,
 };
+
+void flow_init(void)
+{
+	built_in_register(&iftest_func);
+	built_in_register(&ifjump_func);
+	built_in_register(&if_func);
+	built_in_register(&exit_func);
+}

--- a/src/libply/built-in/math.c
+++ b/src/libply/built-in/math.c
@@ -79,7 +79,7 @@ static int unary_type_infer(const struct func *func, struct node *n)
 }
 
 #define UNARY(_fn, _name)				\
-	__ply_built_in const struct func math_ ## _fn =	\
+	static struct func math_ ## _fn =		\
 	{						\
 		.name = _name,				\
 		.type = &t_unary_func,			\
@@ -184,7 +184,7 @@ static int logop_type_infer(const struct func *func, struct node *n)
 }
 
 #define LOGOP(_fn, _name)				\
-	__ply_built_in const struct func math_ ## _fn =	\
+	static struct func math_ ## _fn =		\
 	{						\
 		.name = _name,				\
 		.type = &t_binop_func,			\
@@ -301,7 +301,7 @@ static int relop_type_infer(const struct func *func, struct node *n)
 }
 
 #define RELOP(_fn, _name)				\
-	__ply_built_in const struct func math_ ## _fn =	\
+	static struct func math_ ## _fn =		\
 	{						\
 		.name = _name,				\
 		.type = &t_binop_func,			\
@@ -419,7 +419,7 @@ static int binop_type_infer(const struct func *func, struct node *n)
 }
 
 #define BINOP(_fn, _name)				\
-	__ply_built_in const struct func math_ ## _fn =	\
+	static struct func math_ ## _fn =		\
 	{						\
 		.name = _name,				\
 		.type = &t_binop_func,			\
@@ -437,3 +437,31 @@ BINOP(sub,     "-");
 BINOP(mul,     "*");
 BINOP(div,     "/");
 BINOP(mod,     "%");
+
+void math_init(void)
+{
+	built_in_register(&math_uminus);
+	built_in_register(&math_bwnot);
+	built_in_register(&math_lognot);
+
+	built_in_register(&math_logand);
+	built_in_register(&math_logor);
+
+	built_in_register(&math_eq);
+	built_in_register(&math_ne);
+	built_in_register(&math_lt);
+	built_in_register(&math_gt);
+	built_in_register(&math_le);
+	built_in_register(&math_ge);
+
+	built_in_register(&math_bitor);
+	built_in_register(&math_bitxor);
+	built_in_register(&math_bitand);
+	built_in_register(&math_shl);
+	built_in_register(&math_shr);
+	built_in_register(&math_add);
+	built_in_register(&math_sub);
+	built_in_register(&math_mul);
+	built_in_register(&math_div);
+	built_in_register(&math_mod);
+}

--- a/src/libply/built-in/memory.c
+++ b/src/libply/built-in/memory.c
@@ -119,7 +119,7 @@ static int strcmp_type_infer(const struct func *func, struct node *n)
 	return 0;
 }
 
-__ply_built_in const struct func strcmp_func = {
+static struct func strcmp_func = {
 	.name = "strcmp",
 	.type = &t_vargs_func,
 	.type_infer = strcmp_type_infer,
@@ -208,14 +208,14 @@ struct type t_mem_func = {
 	.func = { .type = &t_void, .args = f_1arg, .vargs = 1 },
 };
 
-__ply_built_in const struct func mem_func = {
+static struct func mem_func = {
 	.name = "mem",
 	.type = &t_mem_func,
 	.type_infer = mem_type_infer,
 	.ir_post = mem_ir_post,
 };
 
-__ply_built_in const struct func str_func = {
+static struct func str_func = {
 	.name = "str",
 	.type = &t_mem_func,
 	.type_infer = mem_type_infer,
@@ -286,7 +286,7 @@ static int struct_deref_type_infer(const struct func *func, struct node *n)
 	return 0;
 }
 
-__ply_built_in const struct func struct_deref_func = {
+static struct func struct_deref_func = {
 	.name = "->",
 	.type = &t_binop_func,
 	.type_infer = struct_deref_type_infer,
@@ -391,7 +391,7 @@ static int struct_dot_type_infer(const struct func *func, struct node *n)
 	return 0;
 }
 
-__ply_built_in const struct func struct_dot_func = {
+static struct func struct_dot_func = {
 	.name = ".",
 	.type = &t_binop_func,
 	.type_infer = struct_dot_type_infer,
@@ -450,7 +450,7 @@ static int deref_type_infer(const struct func *func, struct node *n)
 	return 0;
 }
 
-__ply_built_in const struct func deref_func = {
+static struct func deref_func = {
 	.name = "u*",
 	.type = &t_unary_func,
 	.type_infer = deref_type_infer,
@@ -546,7 +546,7 @@ static int struct_type_infer(const struct func *func, struct node *n)
 	return 0;
 }
 
-__ply_built_in const struct func struct_func = {
+static struct func struct_func = {
 	.name = ":struct",
 	.type = &t_vargs_func,
 	.type_infer = struct_type_infer,
@@ -657,7 +657,7 @@ static int map_static_validate(const struct func *func, struct node *n)
 	return 0;
 }
 
-__ply_built_in const struct func map_func = {
+static struct func map_func = {
 	.name = "[]",
 	.type_infer = map_type_infer,
 	.static_validate = map_static_validate,
@@ -755,7 +755,7 @@ static int assign_static_validate(const struct func *func, struct node *n)
 	return -EINVAL;
 }
 
-__ply_built_in const struct func assign_func = {
+static struct func assign_func = {
 	.name = "=",
 	.type = &t_binop_func,
 	.type_infer = assign_type_infer,
@@ -772,7 +772,7 @@ static int agg_ir_post(const struct func *func, struct node *n,
 	return map_ir_update(n->expr.args, pb);
 }
 
-__ply_built_in const struct func agg_func = {
+static struct func agg_func = {
 	.name = "@=",
 	.type = &t_binop_func,
 	.type_infer = assign_type_infer,
@@ -821,7 +821,7 @@ static int delete_static_validate(const struct func *func, struct node *n)
 	return -EINVAL;
 }
 
-__ply_built_in const struct func delete_func = {
+static struct func delete_func = {
 	.name = "delete",
 	.type = &t_unary_func,
 	.static_ret = 1,
@@ -830,3 +830,18 @@ __ply_built_in const struct func delete_func = {
 	.ir_pre  = delete_ir_pre,
 	.ir_post = delete_ir_post,
 };
+
+void memory_init(void)
+{
+	built_in_register(&strcmp_func);
+	built_in_register(&str_func);
+	built_in_register(&mem_func);
+	built_in_register(&struct_deref_func);
+	built_in_register(&struct_dot_func);
+	built_in_register(&deref_func);
+	built_in_register(&struct_func);
+	built_in_register(&map_func);
+	built_in_register(&assign_func);
+	built_in_register(&agg_func);
+	built_in_register(&delete_func);
+}

--- a/src/libply/built-in/print.c
+++ b/src/libply/built-in/print.c
@@ -276,7 +276,7 @@ static int printf_type_infer(const struct func *func, struct node *n)
 	return 0;
 }
 
-__ply_built_in const struct func printf_func = {
+static struct func printf_func = {
 	.name = "printf",
 	.type = &t_vargs_func,
 	.type_infer = printf_type_infer,
@@ -351,10 +351,16 @@ static int print_type_infer(const struct func *func, struct node *n)
 	return 0;
 }
 
-__ply_built_in const struct func print_func = {
+static struct func print_func = {
 	.name = "print",
 	.type = &t_vargs_func,
 	.type_infer = print_type_infer,
 
 	.rewrite = print_rewrite,
 };
+
+void print_init(void)
+{
+	built_in_register(&printf_func);
+	built_in_register(&print_func);
+}

--- a/src/libply/built-in/proc.c
+++ b/src/libply/built-in/proc.c
@@ -55,7 +55,7 @@ struct type t_stackid_t = {
 	.fprint = stack_fprint,
 };
 
-__ply_built_in const struct func stackmap_func = {
+static struct func stackmap_func = {
 	.name = ":stackmap",
 };
 
@@ -111,7 +111,7 @@ static int stack_rewrite(const struct func *func, struct node *n,
 	return 1;
 }
 
-__ply_built_in const struct func kprobe_stack_func = {
+static struct func kprobe_stack_func = {
 	.name = "stack",
 	.type = &t_stackid_t,
 	.static_ret = 1,
@@ -156,7 +156,7 @@ static int pid_ir_post(const struct func *func, struct node *n,
 	return 0;
 }
 
-__ply_built_in const struct func pid_func = {
+static struct func pid_func = {
 	.name = "pid",
 	.type = &t_pid_func,
 	.static_ret = 1,
@@ -178,7 +178,7 @@ static int kpid_ir_post(const struct func *func, struct node *n,
 	return 0;
 }
 
-__ply_built_in const struct func kpid_func = {
+static struct func kpid_func = {
 	.name = "kpid",
 	.type = &t_pid_func,
 	.static_ret = 1,
@@ -225,7 +225,7 @@ static int uid_ir_post(const struct func *func, struct node *n,
 }
 
 
-__ply_built_in const struct func uid_func = {
+static struct func uid_func = {
 	.name = "uid",
 	.type = &t_uid_func,
 	.static_ret = 1,
@@ -248,7 +248,7 @@ static int gid_ir_post(const struct func *func, struct node *n,
 	return 0;
 }
 
-__ply_built_in const struct func gid_func = {
+static struct func gid_func = {
 	.name = "gid",
 	.type = &t_uid_func,
 	.static_ret = 1,
@@ -291,7 +291,7 @@ static int cpu_ir_post(const struct func *func, struct node *n,
 	return 0;
 }
 
-__ply_built_in const struct func cpu_func = {
+static struct func cpu_func = {
 	.name = "cpu",
 	.type = &t_cpu_func,
 	.static_ret = 1,
@@ -330,7 +330,7 @@ static int comm_ir_post(const struct func *func, struct node *n,
 	return 0;
 }
 
-__ply_built_in const struct func comm_func = {
+static struct func comm_func = {
 	.name = "comm",
 	.type = &t_comm_func,
 	.static_ret = 1,
@@ -338,7 +338,7 @@ __ply_built_in const struct func comm_func = {
 	.ir_post = comm_ir_post,
 };
 
-__ply_built_in const struct func execname_func = {
+static struct func execname_func = {
 	/* alias to comm */
 	.name = "execname",
 	.type = &t_comm_func,
@@ -499,7 +499,7 @@ static int time_ir_post(const struct func *func, struct node *n,
 	return 0;
 }
 
-__ply_built_in const struct func time_func = {
+static struct func time_func = {
 	.name = "time",
 	.type = &t_time_func,
 	.static_ret = 1,
@@ -507,10 +507,28 @@ __ply_built_in const struct func time_func = {
 	.ir_post = time_ir_post,
 };
 
-__ply_built_in const struct func walltime_func = {
+static struct func walltime_func = {
 	.name = "walltime",
 	.type = &t_walltime_func,
 	.static_ret = 1,
 
 	.ir_post = time_ir_post,
 };
+
+void proc_init(void)
+{
+	built_in_register(&stackmap_func);
+	built_in_register(&kprobe_stack_func);
+
+	built_in_register(&pid_func);
+	built_in_register(&kpid_func);
+	built_in_register(&uid_func);
+	built_in_register(&gid_func);
+
+	built_in_register(&cpu_func);
+	built_in_register(&comm_func);
+	built_in_register(&execname_func);
+
+	built_in_register(&time_func);
+	built_in_register(&walltime_func);
+}

--- a/src/libply/libply.c
+++ b/src/libply/libply.c
@@ -428,3 +428,15 @@ err_free:
 err:
 	return err;
 }
+
+void ply_init(void)
+{
+	static int init_done = 0;
+
+	if (init_done)
+		return;
+
+	provider_init();
+
+	init_done = 1;
+}

--- a/src/libply/libply.c
+++ b/src/libply/libply.c
@@ -437,6 +437,7 @@ void ply_init(void)
 		return;
 
 	provider_init();
+	built_in_init();
 
 	init_done = 1;
 }

--- a/src/libply/provider.c
+++ b/src/libply/provider.c
@@ -11,6 +11,15 @@
 #include <ply/ply.h>
 #include <ply/provider.h>
 
+SLIST_HEAD(provider_list, provider);
+static struct provider_list heads = SLIST_HEAD_INITIALIZER(heads);
+
+/* supported providers */
+extern struct provider kprobe;
+extern struct provider kretprobe;
+extern struct provider tracepoint;
+extern struct provider built_in;
+
 struct provider *provider_get(const char *name)
 {
 	struct provider *p;
@@ -18,14 +27,20 @@ struct provider *provider_get(const char *name)
 
 	search = strtok(strdup(name), ":");
 
-	for (p = &__start_providers; p < &__stop_providers; p++) {
+	SLIST_FOREACH(p, &heads, entry) {
  		if (strstr(p->name, search) == p->name)
 			break;
 	}
 
-	if (p == &__stop_providers)
-		p = NULL;
-
 	free(search);
 	return p;
+}
+
+void provider_init(void)
+{
+	SLIST_INSERT_HEAD(&heads, &built_in, entry);
+	SLIST_INSERT_HEAD(&heads, &tracepoint, entry);
+	SLIST_INSERT_HEAD(&heads, &kretprobe, entry);
+	/* place kprobe at head so that 'k' can match first. */
+	SLIST_INSERT_HEAD(&heads, &kprobe, entry);
 }

--- a/src/libply/provider/kprobe.c
+++ b/src/libply/provider/kprobe.c
@@ -216,7 +216,7 @@ static int kprobe_probe(struct ply_probe *pb)
 	return 0;
 }
 
-__ply_provider struct provider kprobe = {
+struct provider kprobe = {
 	.name = "kprobe",
 	.prog_type = BPF_PROG_TYPE_KPROBE,
 

--- a/src/libply/provider/kretprobe.c
+++ b/src/libply/provider/kretprobe.c
@@ -105,7 +105,7 @@ static int kretprobe_probe(struct ply_probe *pb)
 	return 0;
 }
 
-__ply_provider struct provider kretprobe = {
+struct provider kretprobe = {
 	.name = "kretprobe",
 	.prog_type = BPF_PROG_TYPE_KPROBE,
 

--- a/src/libply/provider/tracepoint.c
+++ b/src/libply/provider/tracepoint.c
@@ -272,7 +272,7 @@ err_free:
 	return err;
 }
 
-__ply_provider struct provider tracepoint = {
+struct provider tracepoint = {
 	.name = "tracepoint",
 	.prog_type = BPF_PROG_TYPE_TRACEPOINT,
 

--- a/src/ply/ply.c
+++ b/src/ply/ply.c
@@ -278,6 +278,8 @@ int main(int argc, char **argv)
 	/* TODO figure this out dynamically. terminfo? */
 	ply_config.unicode = 1;
 
+	ply_init();
+
 	ply_alloc(&ply);
 	ret.val = ply_fparse(ply, src);
 	if (ret.val)


### PR DESCRIPTION
Hello,

I changed the providers and built-ins to use a singly linked list to iterate them instead of having separate sections.  And for a static library, the codes need to have direct references from the main binary to be in the final image.  So I added ply_init() function to initialize the providers and built-ins explicitly.

Fixes: #68