### PR TITLE
Improve wildcard matching in k*probe

### DIFF
--- a/src/libply/provider/xprobe.c
+++ b/src/libply/provider/xprobe.c
@@ -59,7 +59,11 @@ static int xprobe_glob(struct ply_probe *pb, glob_t *gl)
 
 	err = glob(evglob, 0, NULL, gl);
 	free(evglob);
-	return err ? -EINVAL : 0;
+
+	if (!err)
+		return 0;
+
+	return err == GLOB_NOMATCH ? -ENOENT : EINVAL;
 }
 
 static char *xprobe_func(struct ply_probe *pb, char *path)


### PR DESCRIPTION
Hello,

This PR fixes wildcard matcing for kprobe.  It failed with -22 when unsupported functions are included in the pattern.  It should check available_filter_functions in the ftrace directory and remove them.  Also make it return -2 when there's no match.

```
# ply 'k:__x64_sys_* { @[caller] = count(); }'
ply: active
^Cply: deactivating

@:
{ __x64_sys_exit+1 }: 1
{ __x64_sys_fallocate+1 }: 1
{ __x64_sys_open+1 }: 1
{ __x64_sys_newlstat+1 }: 1
{ __x64_sys_dup+1 }: 1
{ __x64_sys_sendmmsg+1 }: 1
{ __x64_sys_getdents64+1 }: 2
{ __x64_sys_pselect6+1 }: 2
{ __x64_sys_timerfd_settime+1 }: 2
{ __x64_sys_bind+1 }: 2
{ __x64_sys_ftruncate+1 }: 3
{ __x64_sys_getsockopt+1 }: 3
{ __x64_sys_clock_nanosleep+1 }: 4
{ __x64_sys_pwrite64+1 }: 4
{ __x64_sys_inotify_add_watch+1 }: 4
{ __x64_sys_accept+1 }: 4
{ __x64_sys_readlinkat+1 }: 5
{ __x64_sys_rt_sigaction+1 }: 6
{ __x64_sys_newstat+1 }: 6
{ __x64_sys_getsockname+1 }: 8
{ __x64_sys_rt_sigprocmask+1 }: 10
{ __x64_sys_brk+1 }: 13
{ __x64_sys_lseek+1 }: 13
{ __x64_sys_connect+1 }: 14
{ __x64_sys_socket+1 }: 17
{ __x64_sys_getrusage+1 }: 22
{ __x64_sys_bpf+1 }: 22
{ __x64_sys_munmap+1 }: 22
{ __x64_sys_kcmp+1 }: 24
{ __x64_sys_setsockopt+1 }: 34
{ __x64_sys_fcntl+1 }: 37
{ __x64_sys_getrandom+1 }: 37
{ __x64_sys_close+1 }: 45
{ __x64_sys_epoll_ctl+1 }: 45
{ __x64_sys_mmap+1 }: 48
{ __x64_sys_sched_getaffinity+1 }: 51
{ __x64_sys_recvfrom+1 }: 53
{ __x64_sys_nanosleep+1 }: 92
{ __x64_sys_sendmsg+1 }: 107
{ __x64_sys_clock_gettime+1 }: 132
{ __x64_sys_mprotect+1 }: 185
{ __x64_sys_openat+1 }: 204
{ __x64_sys_newfstat+1 }: 215
{ __x64_sys_select+1 }: 215
{ __x64_sys_ppoll+1 }: 278
{ __x64_sys_epoll_pwait+1 }: 282
{ __x64_sys_setitimer+1 }: 284
{ __x64_sys_writev+1 }: 617
{ __x64_sys_write+1 }: 919
{ __x64_sys_madvise+1 }: 932
{ __x64_sys_sendto+1 }: 1222
{ __x64_sys_read+1 }: 1442
{ __x64_sys_poll+1 }: 3101
{ __x64_sys_recvmsg+1 }: 4102
{ __x64_sys_ioctl+1 }: 4229
{ __x64_sys_epoll_wait+1 }: 5238
{ __x64_sys_futex+1 }: 8102

```