### PR TITLE
Add 'sum' function for aggregation

### DIFF
--- a/man/ply.1.ronn
+++ b/man/ply.1.ronn
@@ -149,6 +149,9 @@ aggregation functions:
   * `@agg[exprs] = count()`:
     Bump a counter.
 
+  * `@agg[exprs] = sum(scalr-expr)`:
+    Evaluates the argument and aggregates the result.
+
   * `@agg[exprs] = quantize(scalar-expr)`:
     Evaluates the argument and aggregates on the most significant bit
     of the result. In other words, it stores the distribution of the


### PR DESCRIPTION
Add sum() function to calculate total number of some events.

```
# cat readsize.ply
tracepoint:syscalls/sys_exit_read { 
    if (data->ret > 0)
        @bytes[comm] = sum(data->ret);
}

# ply -c 'dd if=/dev/zero of=/dev/null bs=1k count=400' readsize.ply
ply: active
400+0 records in
400+0 records out
409600 bytes (410 kB, 400 KiB) copied, 0.000530946 s, 771 MB/s
ply: deactivating

@bytes:
{ ply             }: 4
{ pipewire-media- }: 64
{ gnome-terminal- }: 161
{ sh              }: 2496
{ dd              }: 413428
```