### PR TITLE
Add BEGIN and END providers

### DIFF
--- a/include/ply/buffer.h
+++ b/include/ply/buffer.h
@@ -36,6 +36,6 @@ struct buffer;
 
 struct buffer *buffer_new(int mapfd);
 
-struct ply_return buffer_loop(struct buffer *buf);
+struct ply_return buffer_loop(struct buffer *buf, int timeout);
 
 #endif	/* _PLY_BUFFER_H */

--- a/include/ply/perf_event.h
+++ b/include/ply/perf_event.h
@@ -11,7 +11,8 @@
 
 struct ply_probe;
 
-int perf_event_attach(struct ply_probe *pb, const char *name);
+int perf_event_attach(struct ply_probe *pb, const char *name,
+		      int task_mode);
 
 int perf_event_enable (int group_fd);
 int perf_event_disable(int group_fd);

--- a/include/ply/ply.h
+++ b/include/ply/ply.h
@@ -86,7 +86,7 @@ struct ply_return ply_loop(struct ply *ply);
 int ply_start(struct ply *ply);
 int ply_stop(struct ply *ply);
 
-int ply_load(struct ply *ply);
+struct ply_return ply_load(struct ply *ply);
 int ply_unload(struct ply *ply);
 
 int ply_add_probe(struct ply *ply, struct ply_probe *probe);

--- a/include/ply/ply.h
+++ b/include/ply/ply.h
@@ -38,6 +38,7 @@ struct ply_probe {
 
 	struct ir *ir;
 	int bpf_fd;
+	int special;
 };
 
 struct ply_config {
@@ -98,5 +99,9 @@ void ply_free  (struct ply *ply);
 int  ply_alloc (struct ply **plyp);
 
 void ply_init(void);
+
+typedef void (*special_probe_t)(void);
+
+int register_special_probes(special_probe_t begin, special_probe_t end);
 
 #endif	/* _PLY_H */

--- a/include/ply/ply.h
+++ b/include/ply/ply.h
@@ -98,10 +98,8 @@ int  ply_parsef(struct ply *ply, const char *fmt, ...);
 void ply_free  (struct ply *ply);
 int  ply_alloc (struct ply **plyp);
 
-void ply_init(void);
-
 typedef void (*special_probe_t)(void);
 
-int register_special_probes(special_probe_t begin, special_probe_t end);
+void ply_init(special_probe_t begin, special_probe_t end);
 
 #endif	/* _PLY_H */

--- a/include/ply/provider.h
+++ b/include/ply/provider.h
@@ -32,4 +32,7 @@ struct provider {
 struct provider *provider_get(const char *name);
 void provider_init(void);
 
+void trigger_begin_probe(struct ply_probe *pb);
+void trigger_end_probe(struct ply_probe *pb);
+
 #endif	/* _PROVIDER_H */

--- a/man/ply.1.ronn
+++ b/man/ply.1.ronn
@@ -329,6 +329,13 @@ struct data {
 };
     ```
 
+### BEGIN and END
+
+These special providers are called at the beginning and the end of the
+tracing session like awk and bpftrace.  The names are case sensitive.
+Users can print some messages or fill maps to known info.
+
+
 ## EXAMPLE
 
 ### Extracting data

--- a/src/libply/Makefile.am
+++ b/src/libply/Makefile.am
@@ -40,6 +40,7 @@ libply_la_SOURCES     = 	\
 	provider/tracepoint.c	\
 	provider/xprobe.c	\
 	provider/xprobe.h	\
+	provider/special.c	\
 	\
 	compile.c		\
 	func.c			\

--- a/src/libply/lexer.l
+++ b/src/libply/lexer.l
@@ -63,6 +63,9 @@ pspec		{ident}:[^ \n\r\t]*
 "!="			{ return NE;      }
 "->"			{ return DEREF;   }
 
+"BEGIN"			{ *yylval = node_string(yylloc, strdup(yytext));       return PSPEC;  }
+"END"			{ *yylval = node_string(yylloc, strdup(yytext));       return PSPEC;  }
+
 \"[^\0\"]*\"		{ *yylval = node_string(yylloc, strdup(yytext));       return STRING; }
 [_0-9]+			{ *yylval = node_num   (yylloc, strdup(yytext));       return NUMBER; }
 0b[_01]+		{ *yylval = node_num   (yylloc, strdup(yytext));       return NUMBER; }

--- a/src/libply/libply.c
+++ b/src/libply/libply.c
@@ -374,7 +374,7 @@ struct ply_return ply_loop(struct ply *ply)
 		return (struct ply_return){ .err = 1, .val = EINTR };
 	}
 
-	return buffer_loop((struct buffer *)ply->stdbuf->priv);
+	return buffer_loop((struct buffer *)ply->stdbuf->priv, -1);
 }
 
 int ply_stop(struct ply *ply)

--- a/src/libply/provider.c
+++ b/src/libply/provider.c
@@ -19,6 +19,8 @@ extern struct provider kprobe;
 extern struct provider kretprobe;
 extern struct provider tracepoint;
 extern struct provider built_in;
+extern struct provider begin_provider;
+extern struct provider end_provider;
 
 struct provider *provider_get(const char *name)
 {
@@ -38,6 +40,8 @@ struct provider *provider_get(const char *name)
 
 void provider_init(void)
 {
+	SLIST_INSERT_HEAD(&heads, &end_provider, entry);
+	SLIST_INSERT_HEAD(&heads, &begin_provider, entry);
 	SLIST_INSERT_HEAD(&heads, &built_in, entry);
 	SLIST_INSERT_HEAD(&heads, &tracepoint, entry);
 	SLIST_INSERT_HEAD(&heads, &kretprobe, entry);

--- a/src/libply/provider/special.c
+++ b/src/libply/provider/special.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright  Namhyung Kim <namhyung@gmail.com>
+ *
+ * SPDX-License-Identifier: GPL-2.0
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+
+#include <ply/ply.h>
+#include <ply/internal.h>
+
+#include "xprobe.h"
+
+static char exename[PATH_MAX];
+static special_probe_t begin_fn;
+static special_probe_t end_fn;
+static unsigned long begin_offset;
+static unsigned long end_offset;
+
+int register_special_probes(special_probe_t begin, special_probe_t end)
+{
+	FILE *fp;
+	char buf[PATH_MAX];
+	unsigned long base_addr;
+
+	if (begin == NULL && end == NULL)
+		return 0;
+
+	begin_fn = begin;
+	end_fn = end;
+
+	if (!realpath("/proc/self/exe", exename)) {
+		_w("cannot read pathname of the process image\n");
+		return -1;
+	}
+
+	fp = fopen("/proc/self/maps", "r");
+	if (fp == NULL) {
+		_w("cannot read memory mapping info\n");
+		return -1;
+	}
+	while (fgets(buf, sizeof(buf), fp)) {
+		unsigned long start, end;
+		unsigned long off, ino;
+		char prot[8];
+		char dev[8];
+		char path[PATH_MAX];
+
+		if (sscanf(buf, "%lx-%lx %s %lx %s %lu %s\n",
+			   &start, &end, prot, &off, dev, &ino, path) != 7)
+			continue;
+
+		if (strcmp(path, exename))
+			continue;
+
+		base_addr = start;
+		break;
+	}
+	fclose(fp);
+
+	begin_offset = (unsigned long)begin - base_addr;
+	end_offset = (unsigned long)end - base_addr;
+	return 0;
+}
+
+void trigger_begin_probe(struct ply_probe *pb)
+{
+	struct xprobe *xp = pb->provider_data;
+
+	/* special probe isn't in a perf event group */
+	perf_event_enable(xp->evfds[0]);
+
+	begin_fn();
+}
+
+void trigger_end_probe(struct ply_probe *pb)
+{
+	struct xprobe *xp = pb->provider_data;
+
+	/* special probe isn't in a perf event group */
+	perf_event_enable(xp->evfds[0]);
+
+	end_fn();
+}
+
+static int special_sym_alloc(struct ply_probe *pb, struct node *n)
+{
+	return -ENOENT;
+}
+
+static int special_probe(struct ply_probe *pb)
+{
+	struct xprobe *xp;
+	unsigned long offset = begin_offset;
+
+	if (!strcmp(pb->provider->name, "END"))
+		offset = end_offset;
+
+	/* should not happen */
+	if (offset == 0) {
+		_e("cannot use special provider\n");
+		return -1;
+	}
+
+	xp = xcalloc(1, sizeof(*xp));
+	xp->type = 'p';
+	xp->ctrl_name = "uprobe_events";
+	asprintf(&xp->pattern, "%s:%lu", exename, offset);
+	assert(xp->pattern);
+
+	pb->provider_data = xp;
+	pb->special = 1;
+	return 0;
+}
+
+struct provider begin_provider = {
+	.name = "BEGIN",
+	.prog_type = BPF_PROG_TYPE_KPROBE,
+
+	.probe     = special_probe,
+	.sym_alloc = special_sym_alloc,
+
+	.attach = xprobe_attach,
+	.detach = xprobe_detach,
+};
+
+struct provider end_provider = {
+	.name = "END",
+	.prog_type = BPF_PROG_TYPE_KPROBE,
+
+	.probe     = special_probe,
+	.sym_alloc = special_sym_alloc,
+
+	.attach = xprobe_attach,
+	.detach = xprobe_detach,
+};

--- a/src/libply/provider/tracepoint.c
+++ b/src/libply/provider/tracepoint.c
@@ -207,7 +207,7 @@ static int tracepoint_attach(struct ply_probe *pb)
 {
 	struct tracepoint *tp = pb->provider_data;
 
-	tp->evfd = perf_event_attach(pb, tp->path);
+	tp->evfd = perf_event_attach(pb, tp->path, 0);
 	if (tp->evfd < 0)
 		return tp->evfd;
 

--- a/src/libply/provider/xprobe.c
+++ b/src/libply/provider/xprobe.c
@@ -31,11 +31,19 @@ static int xprobe_stem(struct ply_probe *pb, char type, char *stem, size_t size)
 
 static int __xprobe_create(FILE *ctrl, const char *stem, const char *func)
 {
-	char *funcname = strdup(func);
+	char *funcname;
 	char *offs;
 
+	if (strchr(func, '/'))
+		funcname = strdup(strrchr(func, '/') + 1);
+	else
+		funcname = strdup(func);
 	assert(funcname);
+
 	offs = strchr(funcname, '+');
+	if (offs)
+		*offs = '_';
+	offs = strchr(funcname, ':');
 	if (offs)
 		*offs = '_';
 
@@ -206,7 +214,8 @@ static int __xprobe_attach(struct ply_probe *pb)
 	
 	assert(gl.gl_pathc == xp->n_evs);
 	for (i = 0; i < (int)gl.gl_pathc; i++) {
-		xp->evfds[i] = perf_event_attach(pb, gl.gl_pathv[i], 0);
+		xp->evfds[i] = perf_event_attach(pb, gl.gl_pathv[i],
+						 pb->special);
 		if (xp->evfds[i] < 0) {
 			err = xp->evfds[i];
 			break;

--- a/src/libply/provider/xprobe.c
+++ b/src/libply/provider/xprobe.c
@@ -206,7 +206,7 @@ static int __xprobe_attach(struct ply_probe *pb)
 	
 	assert(gl.gl_pathc == xp->n_evs);
 	for (i = 0; i < (int)gl.gl_pathc; i++) {
-		xp->evfds[i] = perf_event_attach(pb, gl.gl_pathv[i]);
+		xp->evfds[i] = perf_event_attach(pb, gl.gl_pathv[i], 0);
 		if (xp->evfds[i] < 0) {
 			err = xp->evfds[i];
 			break;

--- a/src/ply/ply.c
+++ b/src/ply/ply.c
@@ -281,7 +281,7 @@ int main(int argc, char **argv)
 	/* TODO figure this out dynamically. terminfo? */
 	ply_config.unicode = 1;
 
-	ply_init();
+	ply_init(NULL, NULL);
 
 	ply_alloc(&ply);
 	ret.val = ply_fparse(ply, src);

--- a/src/ply/ply.c
+++ b/src/ply/ply.c
@@ -224,6 +224,9 @@ static const struct sigaction term_action = {
 	.sa_flags = 0,
 };
 
+void __attribute__((noinline)) ply_begin_trigger(void) { asm volatile (""); }
+void __attribute__((noinline)) ply_end_trigger(void) { asm volatile (""); }
+
 int main(int argc, char **argv)
 {
 	struct ply *ply;
@@ -281,7 +284,7 @@ int main(int argc, char **argv)
 	/* TODO figure this out dynamically. terminfo? */
 	ply_config.unicode = 1;
 
-	ply_init(NULL, NULL);
+	ply_init(ply_begin_trigger, ply_end_trigger);
 
 	ply_alloc(&ply);
 	ret.val = ply_fparse(ply, src);
@@ -306,7 +309,7 @@ int main(int argc, char **argv)
 		goto err;
 
 	ply_start(ply);
-	fprintf(stderr, "ply: active\n");
+	_d("ply: active\n");
 
 	sigaction(SIGINT, &term_action, NULL);
 	sigaction(SIGCHLD, &term_action, NULL);
@@ -326,7 +329,7 @@ int main(int argc, char **argv)
 	if (ret.err && (ret.val == EINTR) && term_sig)
 		ret.err = 0;
 stop:
-	fprintf(stderr, "ply: deactivating\n");
+	_d("ply: deactivating\n");
 	ply_stop(ply);
 
 	ply_maps_print(ply);

--- a/src/ply/ply.c
+++ b/src/ply/ply.c
@@ -304,8 +304,8 @@ int main(int argc, char **argv)
 
 	memlock_uncap();
 
-	ret.val = ply_load(ply);
-	if (ret.val)
+	ret = ply_load(ply);
+	if (ret.exit || ret.err)
 		goto err;
 
 	ply_start(ply);

--- a/src/ply/self-test.sh
+++ b/src/ply/self-test.sh
@@ -19,8 +19,9 @@ fi
 
 if [ "$kconf" ]; then
     $kconf | awk '
-        /^CONFIG_BPF_SYSCALL=y$/    { bpf=1 }
+	/^CONFIG_BPF_SYSCALL=y$/    { bpf=1 }
 	/^CONFIG_KPROBES=y$/        { kprobes=1 }
+	/^CONFIG_UPROBES=y$/        { uprobes=1 }
 	/^CONFIG_TRACEPOINTS=y$/    { tracepoints=1 }
 	/^CONFIG_FTRACE=y$/         { ftrace=1 }
 	/^CONFIG_DYNAMIC_FTRACE=y$/ { dftrace=1 }
@@ -38,6 +39,8 @@ if [ "$kconf" ]; then
 	       print("  CONFIG_BPF_SYSCALL is not set");
 	    if (!kprobes)
 	       print("  CONFIG_KPROBES is not set");
+	    if (!uprobes)
+	       print("  CONFIG_UPROBES is not set");
 	    if (!tracepoints)
 	       print("  CONFIG_TRACEPOINTS is not set");
 	    if (!ftrace)
@@ -75,6 +78,14 @@ fi
 
 echo -n "Verifying tracepoint... "
 if $PLYBIN 'tracepoint:sched/sched_switch { exit(0); }' 2>/dev/null; then
+    echo "OK"
+else
+    echo "ERROR"
+    err=1
+fi
+
+echo -n "Verifying special... "
+if $PLYBIN 'BEGIN { exit(0); }' 2>/dev/null; then
     echo "OK"
 else
     echo "ERROR"


### PR DESCRIPTION
Like awk(1) and bpftrace(8), add BEGIN and END (case-sensitive) providers to do things before and after other providers.  This can be useful to print some header message and/or set up maps to predefined values.

The way it's implemented is to use basic uprobe infra (using xprobe code).  Add two empty functions for each trigger and call it when probes are added.  But I needed to calculate (file) offsets of the functions without having an ELF parser.  So I used auxv to get ELF program header (and its virtual address).  Not sure if there's a better way but it works for me. :)

Also I added the BEGIN and END keywords as PSPEC without a colon to match with the existing convention in awk/bpftrace.

For example:
```
# cat opensnoop.ply
BEGIN {
  printf("%7s  %16s  %s\n", "PID", "COMM", "FILE");
}

kprobe:__x64_sys_open {
  printf("%7d  %16s  %s\n", pid, comm, str(arg1));
}

END {
  printf("DONE\n");
}
```

The output looks like:

```
# ply -c 'sleep 1' opensnoop.ply 
    PID              COMM  FILE
1923473                sh  /etc/ld.so.cache
1923473                sh  /lib/x86_64-linux-gnu/libtinfo.so.6
2098992   futex-default-S  /proc/2299637
2098992   futex-default-S  /proc/2299650
2098992   futex-default-S  /proc/2299645
2098992   futex-default-S  /proc/2299643
2098992   futex-default-S  /proc/2299651
  32147   systemd-journal  /proc/1034/comm
  32147   systemd-journal  /proc/1034/cmdline
  32147   systemd-journal  /proc/1034/status
DONE
