### PR TITLE
Add 'interval' provider

### DIFF
--- a/include/ply/internal.h
+++ b/include/ply/internal.h
@@ -25,4 +25,6 @@
 
 void built_in_init(void);
 
+#define ARRAY_SIZE(a)  (sizeof(a) / sizeof(a[0]))
+
 #endif	/* _PLY_INTERNAL_H */

--- a/include/ply/perf_event.h
+++ b/include/ply/perf_event.h
@@ -13,6 +13,8 @@ struct ply_probe;
 
 int perf_event_attach(struct ply_probe *pb, const char *name,
 		      int task_mode);
+int perf_event_attach_raw(struct ply_probe *pb, int type, unsigned long config,
+			  unsigned long long period, int task_mode);
 
 int perf_event_enable (int group_fd);
 int perf_event_disable(int group_fd);

--- a/include/ply/ply.h
+++ b/include/ply/ply.h
@@ -81,6 +81,7 @@ static inline struct ply_probe *sym_to_probe(struct sym *sym)
 
 void ply_maps_print(struct ply *ply);
 void ply_map_print(struct ply *ply, struct sym *sym, FILE *fp);
+void ply_map_clear(struct ply *ply, struct sym *sym);
 
 struct ply_return ply_loop(struct ply *ply);
 

--- a/include/ply/ply.h
+++ b/include/ply/ply.h
@@ -80,6 +80,7 @@ static inline struct ply_probe *sym_to_probe(struct sym *sym)
 }
 
 void ply_maps_print(struct ply *ply);
+void ply_map_print(struct ply *ply, struct sym *sym, FILE *fp);
 
 struct ply_return ply_loop(struct ply *ply);
 

--- a/man/ply.1.ronn
+++ b/man/ply.1.ronn
@@ -337,6 +337,23 @@ These special providers are called at the beginning and the end of the
 tracing session like awk and bpftrace.  The names are case sensitive.
 Users can print some messages or fill maps to known info.
 
+### interval
+
+The interval provider will be trigger at each given interval.
+Users can specify time and unit (optional). If unit is omitted, then
+second is used.  The supported units are:
+
+  * m: minutes
+  * s: seconds  (default)
+  * ms: milli-seconds
+  * us: micro-seconds
+  * ns: nano-seconds
+
+Examples:
+
+  * _interval:1_: Called for every second
+  * _interval:500ms_: Called for every 500 milli-second
+
 
 ## EXAMPLE
 

--- a/man/ply.1.ronn
+++ b/man/ply.1.ronn
@@ -132,6 +132,8 @@ The _delete_ keyword can be used to remove an association from a map:
 
     delete mapname[exprs]
 
+You can also remove all elements in the map using _clear_ function.
+
 
 ### Aggregations
 

--- a/src/libply/Makefile.am
+++ b/src/libply/Makefile.am
@@ -34,13 +34,14 @@ libply_la_SOURCES     = 	\
 	built-in/print.c	\
 	built-in/proc.c		\
 	\
+	provider/interval.c	\
 	provider/kprobe.c	\
 	provider/kprobe.h	\
 	provider/kretprobe.c	\
+	provider/special.c	\
 	provider/tracepoint.c	\
 	provider/xprobe.c	\
 	provider/xprobe.h	\
-	provider/special.c	\
 	\
 	compile.c		\
 	func.c			\

--- a/src/libply/aux/perf_event.c
+++ b/src/libply/aux/perf_event.c
@@ -57,10 +57,36 @@ int perf_event_attach(struct ply_probe *pb, const char *path,
 	if (fd < 0)
 		return -errno;
 
-	/* if (ioctl(fd, PERF_EVENT_IOC_ENABLE, 0)) { */
-	/* 	close(fd); */
-	/* 	return -errno; */
-	/* } */
+	if (ioctl(fd, PERF_EVENT_IOC_SET_BPF, pb->bpf_fd)) {
+		close(fd);
+		return -errno;
+	}
+
+	if (pb->ply->group_fd == -1 && !task_mode)
+		pb->ply->group_fd = fd;
+
+	return fd;
+}
+
+int perf_event_attach_raw(struct ply_probe *pb, int type, unsigned long config,
+			  unsigned long long period, int task_mode)
+{
+	struct perf_event_attr attr = {};
+	int fd;
+	int pid = task_mode ? 0 : -1;
+	int cpu = task_mode ? -1 : 0;
+	int group_fd = task_mode ? -1 : pb->ply->group_fd;
+
+	attr.type = type;
+	attr.config = config;
+	attr.sample_type = PERF_SAMPLE_RAW;
+	attr.sample_period = period;
+	attr.wakeup_events = 1;
+	attr.disabled = 1;
+
+	fd = perf_event_open(&attr, pid, cpu, group_fd, 0);
+	if (fd < 0)
+		return -errno;
 
 	if (ioctl(fd, PERF_EVENT_IOC_SET_BPF, pb->bpf_fd)) {
 		close(fd);

--- a/src/libply/built-in/memory.c
+++ b/src/libply/built-in/memory.c
@@ -556,7 +556,6 @@ static struct func struct_func = {
 };
 
 
-
 static int map_ir_update(struct node *n, struct ply_probe *pb)
 {
 	struct node *map, *key;

--- a/src/libply/grammar.y
+++ b/src/libply/grammar.y
@@ -213,6 +213,7 @@ basic
 : NUMBER
 | STRING
 | IDENT
+| AGG
 | '(' expr ')'	{ $$ = $2; }
 ;
 

--- a/src/libply/libply.c
+++ b/src/libply/libply.c
@@ -25,7 +25,7 @@ struct ply_config ply_config = {
 	.strict = 1,
 };
 
-static void ply_map_print(struct ply *ply, struct sym *sym)
+void ply_map_print(struct ply *ply, struct sym *sym, FILE *fp)
 {
 	struct type *t = sym->type;
 	size_t key_size, val_size, row_size, n_elems;
@@ -63,10 +63,13 @@ static void ply_map_print(struct ply *ply, struct sym *sym)
 	if (ply_config.sort)
 		qsort_r(data, n_elems, row_size, type_cmp, t);
 
-	printf("\n%s:\n", sym->name);
+	fprintf(fp, "\n%s:\n", sym->name);
 	for (row = data; n_elems > 0; row += row_size, n_elems--) {
-		type_fprint(t, stdout, row);
-		fputc('\n', stdout);
+		type_fprint(t->map.ktype, fp, row);
+		fputs(": ", fp);
+
+		type_fprint(t->map.vtype, fp, row + type_sizeof(t->map.ktype));
+		fputc('\n', fp);
 	}
 
 err_free:
@@ -83,7 +86,7 @@ void ply_maps_print(struct ply *ply)
 		if (sym->type->ttype == T_MAP
 		    && sym->type->map.mtype != BPF_MAP_TYPE_PERF_EVENT_ARRAY
 		    && sym->type->map.mtype != BPF_MAP_TYPE_STACK_TRACE)
-			ply_map_print(ply, sym);
+			ply_map_print(ply, sym, stdout);
 	}	
 }
 

--- a/src/libply/provider.c
+++ b/src/libply/provider.c
@@ -21,6 +21,7 @@ extern struct provider tracepoint;
 extern struct provider built_in;
 extern struct provider begin_provider;
 extern struct provider end_provider;
+extern struct provider interval;
 
 struct provider *provider_get(const char *name)
 {
@@ -43,6 +44,7 @@ void provider_init(void)
 	SLIST_INSERT_HEAD(&heads, &end_provider, entry);
 	SLIST_INSERT_HEAD(&heads, &begin_provider, entry);
 	SLIST_INSERT_HEAD(&heads, &built_in, entry);
+	SLIST_INSERT_HEAD(&heads, &interval, entry);
 	SLIST_INSERT_HEAD(&heads, &tracepoint, entry);
 	SLIST_INSERT_HEAD(&heads, &kretprobe, entry);
 	/* place kprobe at head so that 'k' can match first. */

--- a/src/libply/provider/interval.c
+++ b/src/libply/provider/interval.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright  Namhyung Kim <namhyung@gmail.com>
+ *
+ * SPDX-License-Identifier: GPL-2.0
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <ply/ply.h>
+#include <ply/internal.h>
+
+
+struct interval_data {
+	unsigned long long interval;
+	int fd;
+};
+
+static int interval_sym_alloc(struct ply_probe *pb, struct node *n)
+{
+	return -ENOENT;
+}
+
+static int interval_probe(struct ply_probe *pb)
+{
+	char *unit;
+	char *num;
+	size_t i;
+	unsigned long long intvl;
+	struct interval_data *data;
+	struct {
+		const char *str;
+		unsigned long long factor;
+	} interval_units[] = {
+		{ "m"  , 60 * 1e9 },
+		{ "s"  , 1e9 },
+		{ "ms" , 1e6 },
+		{ "us" , 1e3 },
+		{ "ns" , 1 },
+	};
+
+	num = strchr(pb->probe, ':');
+	if (num == NULL) {
+		_e("interval doesn't have unit: %s\n", pb->probe);
+		return -1;
+	}
+	num = strdup(num + 1);
+	if (num == NULL) {
+		_e("memory allocation failure\n");
+		return -1;
+	}
+	intvl = strtoull(num, &unit, 0);
+
+	if (unit == NULL || *unit == '\0')
+		unit = "s";
+
+	for (i = 0; i < ARRAY_SIZE(interval_units); i++) {
+		if (strcmp(unit, interval_units[i].str))
+			continue;
+
+		intvl *= interval_units[i].factor;
+		break;
+	}
+	free(num);
+
+	if (i == ARRAY_SIZE(interval_units)) {
+		_e("invalid time unit: %s\n", pb->probe);
+		return -1;
+	}
+
+	data = xcalloc(1, sizeof(*data));
+	data->interval = intvl;
+	data->fd = -1;
+
+	pb->provider_data = data;
+	return 0;
+}
+
+static int interval_attach(struct ply_probe *pb)
+{
+	struct interval_data *data = pb->provider_data;
+
+	data->fd = perf_event_attach_raw(pb, PERF_TYPE_SOFTWARE,
+					 PERF_COUNT_SW_CPU_CLOCK,
+					 data->interval, 0);
+	if (data->fd < 0) {
+		_e("interval attach failed\n");
+		return data->fd;
+	}
+	return 0;
+}
+
+static int interval_detach(struct ply_probe *pb)
+{
+	struct interval_data *data = pb->provider_data;
+
+	close(data->fd);
+	data->fd = -1;
+	return 0;
+}
+
+struct provider interval = {
+	.name = "interval",
+	.prog_type = BPF_PROG_TYPE_PERF_EVENT,
+
+	.sym_alloc = interval_sym_alloc,
+	.probe     = interval_probe,
+
+	.attach = interval_attach,
+	.detach = interval_detach,
+};

--- a/src/libply/type.c
+++ b/src/libply/type.c
@@ -284,23 +284,16 @@ static int type_fprint_array(struct type *t, FILE *fp, const void *data)
 
 static int type_fprint_map(struct type *t, FILE *fp, const void *data)
 {
-	int ret, total = 0;
+	struct ply *ply = (struct ply *)data;
+	struct sym **symp;
 
-	ret = type_fprint(t->map.ktype, fp, data);
-	if (ret < 0)
-		return ret;
-
-	total += ret;
-
-	fputs(": ", fp);
-	total += 2;
-
-	ret = type_fprint(t->map.vtype, fp, data + type_sizeof(t->map.ktype));
-	if (ret < 0)
-		return ret;
-
-	total += ret;
-	return total;
+	symtab_foreach(&ply->globals, symp) {
+		if ((*symp)->type == t) {
+			ply_map_print(ply, *symp, fp);
+			break;
+		}
+	}
+	return 0;
 }
 
 int type_fprint_struct(struct type *t, FILE *fp, const void *data)

--- a/src/ply/self-test.sh
+++ b/src/ply/self-test.sh
@@ -92,4 +92,12 @@ else
     err=1
 fi
 
+echo -n "Verifying interval... "
+if $PLYBIN 'interval:1s { exit(0); }' 2>/dev/null; then
+    echo "OK"
+else
+    echo "ERROR"
+    err=1
+fi
+
 exit $err

--- a/test/test.sh
+++ b/test/test.sh
@@ -49,4 +49,12 @@ ply -c \
 grep -qe '8k\s*,\s*16k\s*)\s*10' /tmp/quantize \
 || fail "10 reads in (8k, 16k]" "$(cat /tmp/quantize)"
 
+case=interval
+ply -c 'for i in `seq 3`; do dd if=/dev/zero of=/dev/null count=10; sleep 1; done' \
+    'k:vfs_read { @[pid] = count(); }
+     i:1 { print(@); clear(@); }' >/tmp/interval \
+&& \
+cat /tmp/interval | awk '/^@:/ { count++; } END { exit(count < 3); }' \
+|| fail "at least 3 print" "$(cat /tmp/interval)"
+
 exit $total_fails


### PR DESCRIPTION
Hello!

The interval provider is for something needs to be done periodically.  I think  the most common usecase is to print maps and optionally clear them.  So I added it as well like below:

```
# cat readhist.ply
kretprobe:vfs_read {
    @r["bytes"] = quantize(retval);
}
interval:s:1 {
    print(@r);
    clear(@r);
}

# ply -c 'sleep 3' readhist.ply
...
```

The syntax of the interval is same as bpftrace and users need to specify unit and time.  To handle maps (and aggregations) in the print and clear function, I added a new MAPREF (map reference) type.  The functions will rewrite a map argument to a map reference to pass a map fd.