### PR TITLE
Misc fix

### DIFF
--- a/src/libply/built-in/memory.c
+++ b/src/libply/built-in/memory.c
@@ -629,6 +629,11 @@ static int map_type_infer(const struct func *func, struct node *n)
 		return 0;
 
 	if (map->sym->type) {
+		if (map->sym->type->ttype != T_MAP) {
+			_ne(n, "expect map type, but get %N\n", map);
+			return -EINVAL;
+		}
+
 		if (!n->sym->type)
 			/* given `m[key]` where m's type is known,
 			 * infer that the expression's type is equal

--- a/src/libply/provider/special.c
+++ b/src/libply/provider/special.c
@@ -26,7 +26,7 @@ int register_special_probes(special_probe_t begin, special_probe_t end)
 {
 	FILE *fp;
 	char buf[PATH_MAX];
-	unsigned long base_addr;
+	unsigned long base_addr = 0;
 
 	if (begin == NULL && end == NULL)
 		return 0;


### PR DESCRIPTION
Hello,

This is just a couple of small random fixes,  The first commit fixes a compiler warning and the second improves an error message when user gave a wrong type for a map expression.

Thanks,
Namhyung
