### PR TITLE
ply: Initial support for riscv64

### DIFF
--- a/include/ply/ply.h
+++ b/include/ply/ply.h
@@ -100,8 +100,6 @@ int  ply_parsef(struct ply *ply, const char *fmt, ...);
 void ply_free  (struct ply *ply);
 int  ply_alloc (struct ply **plyp);
 
-typedef void (*special_probe_t)(void);
-
-void ply_init(special_probe_t begin, special_probe_t end);
+void ply_init(void);
 
 #endif	/* _PLY_H */

--- a/include/ply/provider.h
+++ b/include/ply/provider.h
@@ -32,7 +32,4 @@ struct provider {
 struct provider *provider_get(const char *name);
 void provider_init(void);
 
-void trigger_begin_probe(struct ply_probe *pb);
-void trigger_end_probe(struct ply_probe *pb);
-
 #endif	/* _PROVIDER_H */

--- a/include/ply/syscall.h
+++ b/include/ply/syscall.h
@@ -34,4 +34,6 @@ int bpf_map_next  (int fd, void *key, void *next_key);
 int perf_event_open(struct perf_event_attr *hw_event, pid_t pid,
 		    int cpu, int group_fd, unsigned long flags);
 
+int bpf_prog_test_run(int prog_fd);
+
 #endif	/* _PLY_BPF_SYSCALL_H */

--- a/src/libply/arch/riscv64.c
+++ b/src/libply/arch/riscv64.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright Tobias Waldekranz <tobias@waldekranz.com>
+ *
+ * SPDX-License-Identifier: GPL-2.0
+ */
+
+#include <assert.h>
+
+#include <ply/internal.h>
+
+#define arch_typedef(_a, _t) {					\
+		.ttype = T_TYPEDEF,				\
+		.tdef = { .name = #_a, .type = _t },		\
+	}
+
+struct type t_s8  = arch_typedef(s8,  &t_schar);
+struct type t_u8  = arch_typedef(u8,  &t_uchar);
+struct type t_s16 = arch_typedef(s16, &t_sshort);
+struct type t_u16 = arch_typedef(u16, &t_ushort);
+struct type t_s32 = arch_typedef(s32, &t_sint);
+struct type t_u32 = arch_typedef(u32, &t_uint);
+struct type t_s64 = arch_typedef(s64, &t_slong);
+struct type t_u64 = arch_typedef(u64, &t_ulong);
+
+static int reg_fprint(struct type *t, FILE *fp, const void *data)
+{
+	return fprintf(fp, "%#lx", *((unsigned long *)data));
+}
+
+struct type t_reg_t = {
+	.ttype = T_TYPEDEF,
+	.tdef = {
+		.name = "reg_t",
+		.type = &t_ulong,
+	},
+
+	.fprint = reg_fprint,
+};
+
+struct tfield f_pt_regs_fields[] = {
+	{ .name = "pc",      .type = &t_reg_t },
+	{ .name = "ra",      .type = &t_reg_t },
+	{ .name = "sp",      .type = &t_reg_t },
+	{ .name = "gp",      .type = &t_reg_t },
+	{ .name = "tp",      .type = &t_reg_t },
+	{ .name = "t0",      .type = &t_reg_t },
+	{ .name = "t1",      .type = &t_reg_t },
+	{ .name = "t2",      .type = &t_reg_t },
+	{ .name = "s0",      .type = &t_reg_t },
+	{ .name = "s1",      .type = &t_reg_t },
+	{ .name = "a0",      .type = &t_reg_t },
+	{ .name = "a1",      .type = &t_reg_t },
+	{ .name = "a2",      .type = &t_reg_t },
+	{ .name = "a3",      .type = &t_reg_t },
+	{ .name = "a4",      .type = &t_reg_t },
+	{ .name = "a5",      .type = &t_reg_t },
+	{ .name = "a6",      .type = &t_reg_t },
+	{ .name = "a7",      .type = &t_reg_t },
+	{ .name = "s2",      .type = &t_reg_t },
+	{ .name = "s3",      .type = &t_reg_t },
+	{ .name = "s4",      .type = &t_reg_t },
+	{ .name = "s5",      .type = &t_reg_t },
+	{ .name = "s6",      .type = &t_reg_t },
+	{ .name = "s7",      .type = &t_reg_t },
+	{ .name = "s8",      .type = &t_reg_t },
+	{ .name = "s9",      .type = &t_reg_t },
+	{ .name = "s10",     .type = &t_reg_t },
+	{ .name = "s11",     .type = &t_reg_t },
+	{ .name = "t3",      .type = &t_reg_t },
+	{ .name = "t4",      .type = &t_reg_t },
+	{ .name = "t5",      .type = &t_reg_t },
+	{ .name = "t6",      .type = &t_reg_t },
+
+	{ .type = NULL }
+};
+
+struct type t_pt_regs = {
+	.ttype = T_STRUCT,
+
+	.sou = {
+		.name = "pt_regs",
+		.fields = f_pt_regs_fields,
+	},
+};
+
+struct type *arch_types[] = {
+	&t_s8, &t_u8,
+	&t_s16, &t_u16,
+	&t_s32, &t_u32,
+	&t_s64, &t_u64,
+	&t_reg_t, &t_pt_regs,
+
+	NULL
+};
+
+const char *arch_register_argument(int num)
+{
+	switch (num) {
+	case 0: return "a0";
+	case 1: return "a1";
+	case 2: return "a2";
+	case 3: return "a3";
+	case 4: return "a4";
+	case 5: return "a5";
+	case 6: return "a6";
+	}
+
+	return NULL;
+}
+
+const char *arch_register_pc(void)
+{
+	return "pc";
+}
+
+const char *arch_register_return(void)
+{
+	return "a0";
+}
+
+__attribute__((constructor))
+static void arch_init(void)
+{
+	type_struct_layout(&t_pt_regs);
+	type_add_list(arch_types);
+}

--- a/src/libply/aux/syscall.c
+++ b/src/libply/aux/syscall.c
@@ -7,8 +7,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <sys/syscall.h>
-
 #include <linux/bpf.h>
 #include <linux/perf_event.h>
 #include <linux/version.h>
@@ -59,6 +57,15 @@ int bpf_map_create(enum bpf_map_type type, int key_sz, int val_sz, int entries)
 	return syscall(__NR_bpf, BPF_MAP_CREATE, &attr, sizeof(attr));
 }
 
+int bpf_prog_test_run(int prog_fd)
+{
+	union bpf_attr attr;
+
+	memset(&attr, 0, sizeof(attr));
+	attr.test.prog_fd = prog_fd;
+
+	return syscall(__NR_bpf, BPF_PROG_TEST_RUN, &attr, sizeof(attr));
+}
 
 static int bpf_map_op(enum bpf_cmd cmd, int fd,
 		      void *key, void *val_or_next, int flags)

--- a/src/libply/built-in/memory.c
+++ b/src/libply/built-in/memory.c
@@ -140,7 +140,7 @@ static int str_ir_post(const struct func *func, struct node *n,
 	ir_emit_ldbp(pb->ir, BPF_REG_1, n->sym->irs.stack);
 	ir_emit_insn(ir, MOV_IMM((int32_t)type_sizeof(n->sym->type)), BPF_REG_2, 0);
 	ir_emit_sym_to_reg(ir, BPF_REG_3, ptr->sym);
-	ir_emit_insn(ir, CALL(BPF_FUNC_probe_read_str), 0, 0);
+	ir_emit_insn(ir, CALL(BPF_FUNC_probe_read_kernel_str), 0, 0);
 	return 0;
 }
 
@@ -305,7 +305,7 @@ static int struct_dot_ir_pre(const struct func *func, struct node *n,
 		sou->sym->irs.hint.dot = 1;
 
 		/* this also means we need to put ourselves on the
-		 * stack since data will be loaded via probe_read */
+		 * stack since data will be loaded via probe_read_kernel */
 		n->sym->irs.hint.stack = 1;
 	}
 	return 0;
@@ -334,7 +334,7 @@ static int struct_dot_ir_post(const struct func *func, struct node *n,
 
 		ir_emit_sym_to_reg(pb->ir, BPF_REG_3, ptr->sym);
 		ir_emit_insn(pb->ir, ALU64_IMM(BPF_ADD, offset), BPF_REG_3, 0);
-		goto probe_read;
+		goto probe_read_kernel;
 	}
 
 	offset += sou->sym->irs.stack;
@@ -346,10 +346,10 @@ static int struct_dot_ir_post(const struct func *func, struct node *n,
 	}
 
 	ir_emit_insn(pb->ir, ALU_IMM(BPF_ADD, offset), BPF_REG_3, 0);
-probe_read:
+probe_read_kernel:
 	ir_emit_insn(pb->ir, MOV_IMM((int32_t)dst->size), BPF_REG_2, 0);
 	ir_emit_ldbp(pb->ir, BPF_REG_1, dst->stack);
-	ir_emit_insn(pb->ir, CALL(BPF_FUNC_probe_read), 0, 0);
+	ir_emit_insn(pb->ir, CALL(BPF_FUNC_probe_read_kernel), 0, 0);
 	/* TODO if (r0) exit(r0); */
 	return 0;
 }

--- a/src/libply/ir.c
+++ b/src/libply/ir.c
@@ -38,10 +38,10 @@ static const char *bpf_func_name(enum bpf_func_id id)
 		return "map_update_elem";
 	case BPF_FUNC_perf_event_output:
 		return "perf_event_output";
-	case BPF_FUNC_probe_read:
-		return "probe_read";
-	case BPF_FUNC_probe_read_str:
-		return "probe_read_str";
+	case BPF_FUNC_probe_read_kernel:
+		return "probe_read_kernel";
+	case BPF_FUNC_probe_read_kernel_str:
+		return "probe_read_kernel_str";
 	case BPF_FUNC_trace_printk:
 		return "trace_printk";
 	default:
@@ -416,7 +416,7 @@ void ir_emit_read_to_sym(struct ir *ir, struct sym *dst, uint16_t src)
 	if (src != BPF_REG_3)
 		ir_emit_insn(ir, MOV, BPF_REG_3, src);
 
-	ir_emit_insn(ir, CALL(BPF_FUNC_probe_read), 0, 0);
+	ir_emit_insn(ir, CALL(BPF_FUNC_probe_read_kernel), 0, 0);
 	/* TODO if (r0) exit(r0); */
 }
 

--- a/src/libply/provider/special.c
+++ b/src/libply/provider/special.c
@@ -4,89 +4,10 @@
  * SPDX-License-Identifier: GPL-2.0
  */
 
-#include <assert.h>
 #include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <limits.h>
 
 #include <ply/ply.h>
 #include <ply/internal.h>
-
-#include "xprobe.h"
-
-static char exename[PATH_MAX];
-static special_probe_t begin_fn;
-static special_probe_t end_fn;
-static unsigned long begin_offset;
-static unsigned long end_offset;
-
-int register_special_probes(special_probe_t begin, special_probe_t end)
-{
-	FILE *fp;
-	char buf[PATH_MAX];
-	unsigned long base_addr = 0;
-
-	if (begin == NULL && end == NULL)
-		return 0;
-
-	begin_fn = begin;
-	end_fn = end;
-
-	if (!realpath("/proc/self/exe", exename)) {
-		_w("cannot read pathname of the process image\n");
-		return -1;
-	}
-
-	fp = fopen("/proc/self/maps", "r");
-	if (fp == NULL) {
-		_w("cannot read memory mapping info\n");
-		return -1;
-	}
-	while (fgets(buf, sizeof(buf), fp)) {
-		unsigned long start, end;
-		unsigned long off, ino;
-		char prot[8];
-		char dev[8];
-		char path[PATH_MAX];
-
-		if (sscanf(buf, "%lx-%lx %s %lx %s %lu %s\n",
-			   &start, &end, prot, &off, dev, &ino, path) != 7)
-			continue;
-
-		if (strcmp(path, exename))
-			continue;
-
-		base_addr = start;
-		break;
-	}
-	fclose(fp);
-
-	begin_offset = (unsigned long)begin - base_addr;
-	end_offset = (unsigned long)end - base_addr;
-	return 0;
-}
-
-void trigger_begin_probe(struct ply_probe *pb)
-{
-	struct xprobe *xp = pb->provider_data;
-
-	/* special probe isn't in a perf event group */
-	perf_event_enable(xp->evfds[0]);
-
-	begin_fn();
-}
-
-void trigger_end_probe(struct ply_probe *pb)
-{
-	struct xprobe *xp = pb->provider_data;
-
-	/* special probe isn't in a perf event group */
-	perf_event_enable(xp->evfds[0]);
-
-	end_fn();
-}
 
 static int special_sym_alloc(struct ply_probe *pb, struct node *n)
 {
@@ -95,47 +16,22 @@ static int special_sym_alloc(struct ply_probe *pb, struct node *n)
 
 static int special_probe(struct ply_probe *pb)
 {
-	struct xprobe *xp;
-	unsigned long offset = begin_offset;
-
-	if (!strcmp(pb->provider->name, "END"))
-		offset = end_offset;
-
-	/* should not happen */
-	if (offset == 0) {
-		_e("cannot use special provider\n");
-		return -1;
-	}
-
-	xp = xcalloc(1, sizeof(*xp));
-	xp->type = 'p';
-	xp->ctrl_name = "uprobe_events";
-	asprintf(&xp->pattern, "%s:%lu", exename, offset);
-	assert(xp->pattern);
-
-	pb->provider_data = xp;
 	pb->special = 1;
 	return 0;
 }
 
 struct provider begin_provider = {
 	.name = "BEGIN",
-	.prog_type = BPF_PROG_TYPE_KPROBE,
+	.prog_type = BPF_PROG_TYPE_RAW_TRACEPOINT,
 
 	.probe     = special_probe,
 	.sym_alloc = special_sym_alloc,
-
-	.attach = xprobe_attach,
-	.detach = xprobe_detach,
 };
 
 struct provider end_provider = {
 	.name = "END",
-	.prog_type = BPF_PROG_TYPE_KPROBE,
+	.prog_type = BPF_PROG_TYPE_RAW_TRACEPOINT,
 
 	.probe     = special_probe,
 	.sym_alloc = special_sym_alloc,
-
-	.attach = xprobe_attach,
-	.detach = xprobe_detach,
 };

--- a/src/libply/provider/tracepoint.c
+++ b/src/libply/provider/tracepoint.c
@@ -68,7 +68,7 @@ static int tracepoint_dyn_ir_post(const struct func *func, struct node *n,
 	ir_emit_insn(ir, ALU_IMM(BPF_AND, 0xffff), BPF_REG_4, 0);
 	ir_emit_insn(ir, ALU64(BPF_ADD), BPF_REG_3, BPF_REG_4);
 
-	ir_emit_insn(ir, CALL(BPF_FUNC_probe_read), 0, 0);
+	ir_emit_insn(ir, CALL(BPF_FUNC_probe_read_kernel), 0, 0);
 	return 0;
 }
 

--- a/src/ply/ply.c
+++ b/src/ply/ply.c
@@ -224,9 +224,6 @@ static const struct sigaction term_action = {
 	.sa_flags = 0,
 };
 
-void __attribute__((noinline)) ply_begin_trigger(void) { asm volatile (""); }
-void __attribute__((noinline)) ply_end_trigger(void) { asm volatile (""); }
-
 int main(int argc, char **argv)
 {
 	struct ply *ply;
@@ -285,7 +282,7 @@ int main(int argc, char **argv)
 	/* TODO figure this out dynamically. terminfo? */
 	ply_config.unicode = 1;
 
-	ply_init(ply_begin_trigger, ply_end_trigger);
+	ply_init();
 
 	ply_alloc(&ply);
 	ret.val = ply_fparse(ply, src);


### PR DESCRIPTION
Add riscv64 support in ply, and makes BEGIN/END probes more reliable by implementing BPF_PROG_TYPE_RAW_TRACEPOINT probes and then calling BPF_PROG_TEST_RUN on them.

Tested on x86 and riscv64, and it works fine.

Resolves #81. Please take a look, thanks. @wkz @namhyung

Signed-off-by: Mingzheng Xing xingmingzheng@iscas.ac.cn