### PR TITLE
mips: small fixes for self-tests and mips64 ABI

### DIFF
--- a/src/libply/arch/mips.c
+++ b/src/libply/arch/mips.c
@@ -147,7 +147,7 @@ const char *arch_register_argument(int num)
 	case 1: return "a1";
 	case 2: return "a2";
 	case 3: return "a3";
-#ifdef USE_MIPS_N32
+#ifndef _ABIO32 /* n32 or native 64-bit ABI */
 	case 4: return "a4";
 	case 5: return "a5";
 	case 6: return "a6";

--- a/src/ply/self-test.sh
+++ b/src/ply/self-test.sh
@@ -57,7 +57,7 @@ else
 fi
 
 echo -n "Ensuring that debugfs is mounted... "
-if mountpoint -q /sys/kernel/debug; then
+if mount -t debugfs | grep -qw "/sys/kernel/debug"; then
     echo "OK"
 else
     echo "ERROR"


### PR DESCRIPTION
These are fixes for some issues I noticed first building and testing on mips arch under OpenWrt. I'll add any more as I come across them. Please review or comment.

The MIPS64 fix suggests a future test-case checking for argument access would be useful e.g. arg5 on mips64.

And thanks again for `ply`; it's wonderful having this for embedded systems...