### PR TITLE
test: Replace bitrotted netbox links

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -19,13 +19,12 @@ tc-tar = $(call tc,$(1)).tar.bz2
 tc-url = https://toolchains.bootlin.com/downloads/releases/toolchains/$(tc-mach-$(1))/tarballs/$(call tc-tar,$(1))
 
 # CI build of netbox@5401a42ea064
-nb-run = 3861903284
-nb-url = https://nightly.link/westermo/netbox/suites/$(nb-run)/artifacts/$(1)
-nb-url-basis   := $(call nb-url,95999414)
-nb-url-coronet := $(call nb-url,95999415)
-nb-url-dagger  := $(call nb-url,95999416)
-nb-url-envoy   := $(call nb-url,95999417)
-nb-url-zero    := $(call nb-url,95999418)
+nb-url = https://github.com/stschake/netbox/releases/download/2023.ply/netbox-os-$(1).tar.gz.zip
+nb-url-basis   := $(call nb-url,basis)
+nb-url-coronet := $(call nb-url,coronet)
+nb-url-dagger  := $(call nb-url,dagger)
+nb-url-envoy   := $(call nb-url,envoy)
+nb-url-zero    := $(call nb-url,zero)
 
 qemu-opts = \
 	-display none -no-reboot \


### PR DESCRIPTION
Unfortunately the netbox image URLs have stopped working. Additionally complicating this is that the mentioned netbox Git revision is not in any released version, and the netbox project itseelf seems inactive so no release is likely to be forthcoming.

The linked netbox fork is a faithful Git workflow build of the previously used netbox Git revision and as a release should not expire liek the previous nightly version did.

Of course I'd prefer to not have my sketchy fork URL in here - but I'm not sure if there is a better option to host these, and it seemed worth to revive the test/ part of this utility since the whole qemu flow is actually a pretty clever, convenient way of doing it!