### PR TITLE
ply: Correct alignment of stack allocations

### DIFF
--- a/src/libply/ir.c
+++ b/src/libply/ir.c
@@ -520,7 +520,7 @@ ssize_t ir_alloc_stack(struct ir *ir, size_t size, size_t align)
 	ir->sp -= size;
 
 	if (ir->sp % align)
-		ir->sp -= align - (ir->sp & (align - 1));
+		ir->sp &= ~(align - 1);
 
 	assert(ir->sp > INT16_MIN);
 


### PR DESCRIPTION
As entries are allocated on the stack the stack pointer is decremented and then adjusted to meet the requested alignment requirements. The current math does unfortunately not always provide the requested alignment.

One example is when the stack pointer is at -1 and an allocation of 4 bytes with alignment of 4 is performed, which results in an allocation at offset -6. A typical case where this happens is when working with tracepoints containing boolean fields.

Update the adjustment to properly round the stack pointer down to the requested alignment.

Fixes #91 