### PR TITLE
add 'uptr' function to mark userland pointer

### DIFF
--- a/include/ply/ir.h
+++ b/include/ply/ir.h
@@ -148,6 +148,7 @@ struct irstate {
 		int dot:1;
 		int lval:1;
 		int stack:1;
+		int user:1;
 	} hint;
 };
 
@@ -177,7 +178,7 @@ void ir_emit_sym_to_reg  (struct ir *ir, uint16_t dst, struct sym *src);
 void ir_emit_reg_to_sym  (struct ir *ir, struct sym *dst, uint16_t src);
 void ir_emit_sym_to_stack(struct ir *ir, ssize_t offset, struct sym *src);
 void ir_emit_sym_to_sym  (struct ir *ir, struct sym *dst, struct sym *src);
-void ir_emit_read_to_sym (struct ir *ir, struct sym *dst, uint16_t src);
+void ir_emit_read_to_sym (struct ir *ir, struct sym *dst, uint16_t src, int user);
 
 void ir_emit_data  (struct ir *ir, ssize_t dst, const char *src, size_t size);
 void ir_emit_memcpy(struct ir *ir, ssize_t dst, ssize_t src, size_t size);

--- a/src/libply/ir.c
+++ b/src/libply/ir.c
@@ -42,6 +42,10 @@ static const char *bpf_func_name(enum bpf_func_id id)
 		return "probe_read_kernel";
 	case BPF_FUNC_probe_read_kernel_str:
 		return "probe_read_kernel_str";
+	case BPF_FUNC_probe_read_user:
+		return "probe_read_user";
+	case BPF_FUNC_probe_read_user_str:
+		return "probe_read_user_str";
 	case BPF_FUNC_trace_printk:
 		return "trace_printk";
 	default:
@@ -405,7 +409,7 @@ void ir_emit_sym_to_sym(struct ir *ir, struct sym *dst, struct sym *src)
 	}
 }
 
-void ir_emit_read_to_sym(struct ir *ir, struct sym *dst, uint16_t src)
+void ir_emit_read_to_sym(struct ir *ir, struct sym *dst, uint16_t src, int user)
 {
 	struct irstate *irs = &dst->irs;
 
@@ -416,7 +420,10 @@ void ir_emit_read_to_sym(struct ir *ir, struct sym *dst, uint16_t src)
 	if (src != BPF_REG_3)
 		ir_emit_insn(ir, MOV, BPF_REG_3, src);
 
-	ir_emit_insn(ir, CALL(BPF_FUNC_probe_read_kernel), 0, 0);
+	if (user)
+		ir_emit_insn(ir, CALL(BPF_FUNC_probe_read_user), 0, 0);
+	else
+		ir_emit_insn(ir, CALL(BPF_FUNC_probe_read_kernel), 0, 0);
 	/* TODO if (r0) exit(r0); */
 }
 

--- a/src/ply/ply.c
+++ b/src/ply/ply.c
@@ -120,8 +120,10 @@ void dump(struct ply *ply)
 	symtab_dump(&ply->globals, stdout);
 
 	ply_probe_foreach(ply, pb) {
+		printf("\n\n-- probe\n");
 		printf("%s\n", pb->probe ? : "<null>");
 
+		printf("\n\n-- ast\n");
 		if (pb->ast)
 			ast_fprint(stdout, pb->ast);
 		else


### PR DESCRIPTION
Introduce the uptr() function and 'user' hint from @stschake's work to enable explicit marking of userland pointers. This allows expressions like str(uptr(arg0)) to correctly read user memory, resolving the issue where kernel and user pointers could not be distinguished.

As discussed in [issue #87](https://github.com/iovisor/ply/issues/87), this change enables correct filename printing in probes such as:

    kprobe:do_sys_openat2 { printf("%v(%v): %s\n", comm, uid, str(uptr(arg1))); }