### PR TITLE
syscall: fix bpf_map_op for gcc 15 union initialization semantics

### DIFF
--- a/src/libply/aux/syscall.c
+++ b/src/libply/aux/syscall.c
@@ -70,12 +70,12 @@ int bpf_prog_test_run(int prog_fd)
 static int bpf_map_op(enum bpf_cmd cmd, int fd,
 		      void *key, void *val_or_next, int flags)
 {
-	union bpf_attr attr =  {
-		.map_fd = fd,
-		.key = ptr_to_u64(key),
-		.value = ptr_to_u64(val_or_next),
-		.flags = flags,
-	};
+	union bpf_attr attr = {};
+
+	attr.map_fd = fd;
+	attr.key = ptr_to_u64(key);
+	attr.value = ptr_to_u64(val_or_next);
+	attr.flags = flags;
 
 	return syscall(__NR_bpf, cmd, &attr, sizeof(attr));
 }


### PR DESCRIPTION
Ensure full zero-initialization of union bpf_attr in bpf_map_op to accommodate gcc 15 changes.

Starting with gcc 15, initializing a union with {} only zeroes the first member, rather than the entire union [1]. This can lead to uninitialized fields in bpf_attr, causing errors such as:

    # ply 'kprobe:vfs_read { print(comm); }'
    error: could not link map to queue
    error: unable to create buffer 'stdbuf'
    ERR: -22

Fix this by explicitly zero-initializing bpf_attr with {} before assigning its members.

Link: https://gcc.gnu.org/gcc-15/changes.html [1]